### PR TITLE
Update Namespace variable and add lifetime functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,10 @@ To claim a cluster from a ClusterPool:
 You may also consider defining a series of environment variables to "fully automate" the creation of new ClusterClaims once you have one claim under your belt.  The prompts in `apply.sh` will note which environment variable can be defined to skip a given set, but here's a full list for convenience:
 ```
 CLUSTERPOOL_TARGET_NAMESPACE - namespace you want to create/destroy a clusterpool in
-CLUSTERCLAIM_NAME - chosen name for the clusterclaim, must be unique and not contain `.`
+CLUSTERCLAIM_NAME - chosen name for the ClusterClaim, must be unique and not contain `.`
 CLUSTERPOOL_NAME - your chosen name for the clusterpool
+CLUSTERCLAIM_GROUP_NAME - RBAC group to associate with the ClusterClaim
+CLUSTERCLAIM_LIFETIME - lifetime for the cluster claim before automatic deletion, formatted as `1h2m3s` omitting units as desired (set to "false" to disable)
 ```
 **Note:** If you find that the above list does not fully automate clusterclaim creation, then we made a mistake or need to update the list!  Please let us know via a GitHub issue or contribute a patch! 
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To create your first ClusterPool:
 
 You may also consider defining a series of environment variables to "fully automate" the creation of additional clusterpools once you have one clusterpool under your belt.  The prompts in `apply.sh` will note which environment variable can be defined to skip a given set, but here's a full list for convenience:
 ```
-TARGET_NAMESPACE - namespace you want to create/destroy a clusterpool in
+CLUSTERPOOL_TARGET_NAMESPACE - namespace you want to create/destroy a clusterpool in
 PLATFORM - cloud platform you wish to use, must be one of: AWS, AZURE, GCP
 CLOUD_CREDENTIAL_SECRET - name of the secret to be used to access your cloud platform
 OCP_PULL_SECRET - name of the secret containing your OCP pull secret
@@ -62,7 +62,7 @@ To claim a cluster from a ClusterPool:
 
 You may also consider defining a series of environment variables to "fully automate" the creation of new ClusterClaims once you have one claim under your belt.  The prompts in `apply.sh` will note which environment variable can be defined to skip a given set, but here's a full list for convenience:
 ```
-TARGET_NAMESPACE - namespace you want to create/destroy a clusterpool in
+CLUSTERPOOL_TARGET_NAMESPACE - namespace you want to create/destroy a clusterpool in
 CLUSTERCLAIM_NAME - chosen name for the clusterclaim, must be unique and not contain `.`
 CLUSTERPOOL_NAME - your chosen name for the clusterpool
 ```

--- a/clusterclaims/apply.sh
+++ b/clusterclaims/apply.sh
@@ -163,7 +163,7 @@ fi
 if [[ ! -d ./$CLUSTERCLAIM_NAME ]]; then
     mkdir ./$CLUSTERCLAIM_NAME
 fi
-if [[ "$CLUSTERCLAIM_LIFETIME" == "" ]]; then
+if [[ "$CLUSTERCLAIM_LIFETIME" == "" || "$CLUSTERCLAIM_LIFETIME" == "false" ]]; then
     ${SED} -e "s/__CLUSTERCLAIM_NAME__/$CLUSTERCLAIM_NAME/g" \
             -e "s/__CLUSTERPOOL_TARGET_NAMESPACE__/$CLUSTERPOOL_TARGET_NAMESPACE/g" \
             -e "s/__CLUSTERPOOL_NAME__/$CLUSTERPOOL_NAME/g" ./templates/clusterclaim.nolifetime.yaml.template > ./${CLUSTERCLAIM_NAME}/${CLUSTERCLAIM_NAME}.clusterclaim.yaml

--- a/clusterclaims/apply.sh
+++ b/clusterclaims/apply.sh
@@ -47,7 +47,7 @@ VER=`oc version | grep "Server Version:"`
 printf "${BLUE}* ${VER}${CLEAR}\n"
 
 #----SELECT A NAMESPACE----#
-if [[ "$TARGET_NAMESPACE" == "" ]]; then
+if [[ "$CLUSTERPOOL_TARGET_NAMESPACE" == "" ]]; then
     # Prompt the user to choose a project
     projects=$(oc get project -o custom-columns=NAME:.metadata.name,STATUS:.status.phase)
     project_names=()
@@ -66,27 +66,27 @@ if [[ "$TARGET_NAMESPACE" == "" ]]; then
         i=$((i+1))
     done;
     unset IFS
-    printf "${BLUE}- note: to skip this step in the future, export TARGET_NAMESPACE${CLEAR}\n"
+    printf "${BLUE}- note: to skip this step in the future, export CLUSTERPOOL_TARGET_NAMESPACE${CLEAR}\n"
     printf "${YELLOW}Enter the number corresponding to your desired Project/Namespace from the list above:${CLEAR} "
     read selection
     if [ "$selection" -lt "$i" ]; then
-        TARGET_NAMESPACE=${project_names[$(($selection-1))]}
+        CLUSTERPOOL_TARGET_NAMESPACE=${project_names[$(($selection-1))]}
     else
         printf "${RED}Invalid Choice. Exiting.\n${CLEAR}"
         exit 3
     fi
 fi
-oc get projects ${TARGET_NAMESPACE} --no-headers &> /dev/null
+oc get projects ${CLUSTERPOOL_TARGET_NAMESPACE} --no-headers &> /dev/null
 if [[ $? -ne 0 ]]; then
-    printf "${RED}Couldn't find a namespace named ${TARGET_NAMESPACE} on ${HOST_URL}, validate your choice with 'oc get projects' and try again.${CLEAR}\n"
+    printf "${RED}Couldn't find a namespace named ${CLUSTERPOOL_TARGET_NAMESPACE} on ${HOST_URL}, validate your choice with 'oc get projects' and try again.${CLEAR}\n"
     exit 3
 fi
-printf "${GREEN}* Using $TARGET_NAMESPACE\n${CLEAR}"
+printf "${GREEN}* Using ${CLUSTERPOOL_TARGET_NAMESPACE}\n${CLEAR}"
 
 #----SELECT A CLUSTERPOOL TO CLAIM FROM----#
 if [[ "$CLUSTERPOOL_NAME" == "" ]]; then
     # Prompt the user to choose a ClusterImageSet
-    clusterpools=$(oc get clusterpools -n ${TARGET_NAMESPACE})
+    clusterpools=$(oc get clusterpools -n ${CLUSTERPOOL_TARGET_NAMESPACE})
     clusterpool_names=()
     i=0
     IFS=$'\n'
@@ -103,7 +103,7 @@ if [[ "$CLUSTERPOOL_NAME" == "" ]]; then
         i=$((i+1))
     done;
     if [[ "$i" -lt 1 ]]; then
-        printf "${RED}No ClusterPools found in the ${TARGET_NAMESPACE} namespace on ${HOST_URL}.  Please verify that ${TARGET_NAMESPACE} has ClusterPools with 'oc get clusterpool -n $TARGET_NAMESPACE' and try again.${CLEAR}\n"
+        printf "${RED}No ClusterPools found in the ${CLUSTERPOOL_TARGET_NAMESPACE} namespace on ${HOST_URL}.  Please verify that ${CLUSTERPOOL_TARGET_NAMESPACE} has ClusterPools with 'oc get clusterpool -n ${CLUSTERPOOL_TARGET_NAMESPACE}' and try again.${CLEAR}\n"
         exit 3
     fi
     unset IFS
@@ -119,7 +119,7 @@ if [[ "$CLUSTERPOOL_NAME" == "" ]]; then
 else
     oc get clusterpool ${CLUSTERPOOL_NAME} --no-headers &> /dev/null
     if [[ $? -ne 0 ]]; then
-        printf "${RED}Couldn't find a ClusterPool named ${CLUSTERPOOL_NAME} on ${HOST_URL} in the ${TARGET_NAMESPACE} namespace, validate your choice with 'oc get clusterpools -n ${TARGET_NAMESPACE}' and try again.${CLEAR}\n"
+        printf "${RED}Couldn't find a ClusterPool named ${CLUSTERPOOL_NAME} on ${HOST_URL} in the ${CLUSTERPOOL_TARGET_NAMESPACE} namespace, validate your choice with 'oc get clusterpools -n ${CLUSTERPOOL_TARGET_NAMESPACE}' and try again.${CLEAR}\n"
         exit 3
     fi
 fi
@@ -165,11 +165,11 @@ if [[ ! -d ./$CLUSTERCLAIM_NAME ]]; then
 fi
 if [[ "$CLUSTERCLAIM_LIFETIME" == "" ]]; then
     ${SED} -e "s/__CLUSTERCLAIM_NAME__/$CLUSTERCLAIM_NAME/g" \
-            -e "s/__TARGET_NAMESPACE__/$TARGET_NAMESPACE/g" \
+            -e "s/__CLUSTERPOOL_TARGET_NAMESPACE__/$CLUSTERPOOL_TARGET_NAMESPACE/g" \
             -e "s/__CLUSTERPOOL_NAME__/$CLUSTERPOOL_NAME/g" ./templates/clusterclaim.nolifetime.yaml.template > ./${CLUSTERCLAIM_NAME}/${CLUSTERCLAIM_NAME}.clusterclaim.yaml
 else
     ${SED} -e "s/__CLUSTERCLAIM_NAME__/$CLUSTERCLAIM_NAME/g" \
-            -e "s/__TARGET_NAMESPACE__/$TARGET_NAMESPACE/g" \
+            -e "s/__CLUSTERPOOL_TARGET_NAMESPACE__/$CLUSTERPOOL_TARGET_NAMESPACE/g" \
             -e "s/__CLUSTERCLAIM_LIFETIME__/$CLUSTERCLAIM_LIFETIME/g" \
             -e "s/__CLUSTERPOOL_NAME__/$CLUSTERPOOL_NAME/g" ./templates/clusterclaim.lifetime.yaml.template > ./${CLUSTERCLAIM_NAME}/${CLUSTERCLAIM_NAME}.clusterclaim.yaml
 fi
@@ -220,7 +220,7 @@ fi
 
 
 #-----CHECK FOR AVAILABLE CLUSTERS-----#
-avail_clusters=$(oc get clusterpool ${CLUSTERPOOL_NAME} -n ${TARGET_NAMESPACE} -o json | jq -r '.status.ready')
+avail_clusters=$(oc get clusterpool ${CLUSTERPOOL_NAME} -n ${CLUSTERPOOL_TARGET_NAMESPACE} -o json | jq -r '.status.ready')
 if [[ "$avail_clusters" -eq 0 ]]; then
     printf "${BLUE}* No Clusters are available in ${CLUSTERPOOL_NAME}, polling for 60 minutes after claim creation for claim to be fulfilled and awake to allow for cluster provision to occur.${CLEAR}\n"
     POLL_DURATION=3600
@@ -236,7 +236,7 @@ cat ./${CLUSTERCLAIM_NAME}/${CLUSTERCLAIM_NAME}.clusterclaim.yaml
 printf "\n"
 oc apply -f ./${CLUSTERCLAIM_NAME}/${CLUSTERCLAIM_NAME}.clusterclaim.yaml
 if [[ $? -ne 0 ]]; then
-    printf "${RED}Couldn't apply ClusterClaim ${CLUSTERCLAIM_NAME} in ${TARGET_NAMESPACE} on ${HOST_URL}, see the above error message for more details.${CLEAR}\n"
+    printf "${RED}Couldn't apply ClusterClaim ${CLUSTERCLAIM_NAME} in ${CLUSTERPOOL_TARGET_NAMESPACE} on ${HOST_URL}, see the above error message for more details.${CLEAR}\n"
     exit 3
 fi
 printf "* ${GREEN}ClusterClaim ${CLUSTERCLAIM_NAME} on ${CLUSTERPOOL_NAME} successfully created, polling ${POLL_DURATION} seconds for claim to be fulfilled and cluster to become ready.\n${CLEAR}"
@@ -256,7 +256,7 @@ fi
 # Initialize loop variables
 CC_JSON=$CLUSTERCLAIM_NAME/.ClusterClaim.json
 CD_JSON=$CLUSTERCLAIM_NAME/.ClusterDeployment.json
-oc get clusterclaim ${CLUSTERCLAIM_NAME} -n ${TARGET_NAMESPACE} -o json > $CC_JSON
+oc get clusterclaim ${CLUSTERCLAIM_NAME} -n ${CLUSTERPOOL_TARGET_NAMESPACE} -o json > $CC_JSON
 CC_NS=`jq -r '.spec.namespace' $CC_JSON`
 if [[ "$CC_NS" != "null" ]]; then
     oc get clusterdeployment $CC_NS -n $CC_NS -o json > $CD_JSON
@@ -276,7 +276,7 @@ fi
 poll_acc=0
 # Poll for claim to be fulfilled and ready
 while [[ ("$CC_PEND_CONDITION" != "False" || "$CD_HIB_CONDITION" != "False" || "$CD_UNR_CONDITION" != "False") && "$poll_acc" -lt $POLL_DURATION ]]; do
-    oc get clusterclaim ${CLUSTERCLAIM_NAME} -n ${TARGET_NAMESPACE} -o json > $CC_JSON
+    oc get clusterclaim ${CLUSTERCLAIM_NAME} -n ${CLUSTERPOOL_TARGET_NAMESPACE} -o json > $CC_JSON
     CC_NS=`jq -r '.spec.namespace' $CC_JSON`
     if [[ "$CC_NS" != "null" ]]; then
         oc get clusterdeployment $CC_NS -n $CC_NS -o json > $CD_JSON

--- a/clusterclaims/delete.sh
+++ b/clusterclaims/delete.sh
@@ -45,7 +45,7 @@ printf "${BLUE}* ${VER}${CLEAR}\n"
 
 
 #----SELECT A NAMESPACE----#
-if [[ "$TARGET_NAMESPACE" == "" ]]; then
+if [[ "$CLUSTERPOOL_TARGET_NAMESPACE" == "" ]]; then
     # Prompt the user to choose a project
     projects=$(oc get project -o custom-columns=NAME:.metadata.name,STATUS:.status.phase)
     project_names=()
@@ -64,28 +64,28 @@ if [[ "$TARGET_NAMESPACE" == "" ]]; then
         i=$((i+1))
     done;
     unset IFS
-    printf "${BLUE}- note: to skip this step in the future, export TARGET_NAMESPACE${CLEAR}\n"
+    printf "${BLUE}- note: to skip this step in the future, export CLUSTERPOOL_TARGET_NAMESPACE${CLEAR}\n"
     printf "${YELLOW}Enter the number corresponding to your desired Project/Namespace from the list above:${CLEAR} "
     read selection
     if [ "$selection" -lt "$i" ]; then
-        TARGET_NAMESPACE=${project_names[$(($selection-1))]}
+        CLUSTERPOOL_TARGET_NAMESPACE=${project_names[$(($selection-1))]}
     else
         printf "${RED}Invalid Choice. Exiting.\n${CLEAR}"
         exit 3
     fi
 fi
-oc get projects ${TARGET_NAMESPACE} --no-headers &> /dev/null
+oc get projects ${CLUSTERPOOL_TARGET_NAMESPACE} --no-headers &> /dev/null
 if [[ $? -ne 0 ]]; then
-    printf "${RED}Couldn't find a namespace named ${TARGET_NAMESPACE} on ${HOST_URL}, validate your choice with 'oc get projects' and try again.${CLEAR}\n"
+    printf "${RED}Couldn't find a namespace named ${CLUSTERPOOL_TARGET_NAMESPACE} on ${HOST_URL}, validate your choice with 'oc get projects' and try again.${CLEAR}\n"
     exit 3
 fi
-printf "${GREEN}* Using $TARGET_NAMESPACE\n${CLEAR}"
+printf "${GREEN}* Using $CLUSTERPOOL_TARGET_NAMESPACE\n${CLEAR}"
 
 
 #----SELECT A CLUSTERCLAIM TO EXTRACT CREDENTIALS FROM----#
 if [[ "$CLUSTERCLAIM_NAME" == "" ]]; then
     # Prompt the user to choose a ClusterImageSet
-    clusterclaims=$(oc get clusterclaim -n ${TARGET_NAMESPACE})
+    clusterclaims=$(oc get clusterclaim -n ${CLUSTERPOOL_TARGET_NAMESPACE})
     clusterclaim_names=()
     i=0
     IFS=$'\n'
@@ -102,7 +102,7 @@ if [[ "$CLUSTERCLAIM_NAME" == "" ]]; then
         i=$((i+1))
     done;
     if [[ "$i" -lt 1 ]]; then
-        printf "${RED}No ClusterClaims found in the ${TARGET_NAMESPACE} namespace on ${HOST_URL}.  Please verify that ${TARGET_NAMESPACE} has ClusterClaims with 'oc get clusterclaim -n $TARGET_NAMESPACE' and try again.${CLEAR}\n"
+        printf "${RED}No ClusterClaims found in the ${CLUSTERPOOL_TARGET_NAMESPACE} namespace on ${HOST_URL}.  Please verify that ${CLUSTERPOOL_TARGET_NAMESPACE} has ClusterClaims with 'oc get clusterclaim -n $CLUSTERPOOL_TARGET_NAMESPACE' and try again.${CLEAR}\n"
         exit 3
     fi
     unset IFS
@@ -118,7 +118,7 @@ if [[ "$CLUSTERCLAIM_NAME" == "" ]]; then
 else
     oc get clusterclaim ${CLUSTERCLAIM_NAME} --no-headers &> /dev/null
     if [[ $? -ne 0 ]]; then
-        printf "${RED}Couldn't find a ClusterClaim named ${CLUSTERCLAIM_NAME} on ${HOST_URL} in the ${TARGET_NAMESPACE} namespace, validate your choice with 'oc get clusterclaim -n ${TARGET_NAMESPACE}' and try again.${CLEAR}\n"
+        printf "${RED}Couldn't find a ClusterClaim named ${CLUSTERCLAIM_NAME} on ${HOST_URL} in the ${CLUSTERPOOL_TARGET_NAMESPACE} namespace, validate your choice with 'oc get clusterclaim -n ${CLUSTERPOOL_TARGET_NAMESPACE}' and try again.${CLEAR}\n"
         exit 3
     fi
 fi
@@ -127,7 +127,7 @@ printf "${GREEN}* Using: $CLUSTERCLAIM_NAME${CLEAR}\n"
 
 #-----VERIFY INTENT AND DELETE CLUSTERCLAIM-----#
 CC_JSON=$CLUSTERCLAIM_NAME/.ClusterClaim.json
-oc get clusterclaim ${CLUSTERCLAIM_NAME} -n ${TARGET_NAMESPACE} -o json > $CC_JSON
+oc get clusterclaim ${CLUSTERCLAIM_NAME} -n ${CLUSTERPOOL_TARGET_NAMESPACE} -o json > $CC_JSON
 clusterdeployment=`jq -r '.spec.namespace' $CC_JSON`
 if [[ "$CC_NS" != "null" ]]; then
     printf "${YELLOW}Deleting $CLUSTERCLAIM_NAME will destroy the cluster ${BLUE}$clusterdeployment${YELLOW}.${CLEAR}\n"
@@ -138,7 +138,7 @@ if [[ ! ("$selection" == "Y" || "$selection" == "y") ]]; then
     printf "${GREEN} Deletion cancelled, exiting.${CLEAR}\n"
     exit 0
 else
-    oc delete clusterclaim -n $TARGET_NAMESPACE $CLUSTERCLAIM_NAME
+    oc delete clusterclaim -n $CLUSTERPOOL_TARGET_NAMESPACE $CLUSTERCLAIM_NAME
     if [[ "$?" -ne 0 ]]; then
         printf "${RED}Failed to delete ClusterClaim $CLUSTERCLAIM_NAME, see above error message for more detail.${CLEAR}\n"
         exit 3

--- a/clusterclaims/get_credentials.sh
+++ b/clusterclaims/get_credentials.sh
@@ -45,7 +45,7 @@ printf "${BLUE}* ${VER}${CLEAR}\n"
 
 
 #----SELECT A NAMESPACE----#
-if [[ "$TARGET_NAMESPACE" == "" ]]; then
+if [[ "$CLUSTERPOOL_TARGET_NAMESPACE" == "" ]]; then
     # Prompt the user to choose a project
     projects=$(oc get project -o custom-columns=NAME:.metadata.name,STATUS:.status.phase)
     project_names=()
@@ -64,28 +64,28 @@ if [[ "$TARGET_NAMESPACE" == "" ]]; then
         i=$((i+1))
     done;
     unset IFS
-    printf "${BLUE}- note: to skip this step in the future, export TARGET_NAMESPACE${CLEAR}\n"
+    printf "${BLUE}- note: to skip this step in the future, export CLUSTERPOOL_TARGET_NAMESPACE${CLEAR}\n"
     printf "${YELLOW}Enter the number corresponding to your desired Project/Namespace from the list above:${CLEAR} "
     read selection
     if [ "$selection" -lt "$i" ]; then
-        TARGET_NAMESPACE=${project_names[$(($selection-1))]}
+        CLUSTERPOOL_TARGET_NAMESPACE=${project_names[$(($selection-1))]}
     else
         printf "${RED}Invalid Choice. Exiting.\n${CLEAR}"
         exit 3
     fi
 fi
-oc get projects ${TARGET_NAMESPACE} --no-headers &> /dev/null
+oc get projects ${CLUSTERPOOL_TARGET_NAMESPACE} --no-headers &> /dev/null
 if [[ $? -ne 0 ]]; then
-    printf "${RED}Couldn't find a namespace named ${TARGET_NAMESPACE} on ${HOST_URL}, validate your choice with 'oc get projects' and try again.${CLEAR}\n"
+    printf "${RED}Couldn't find a namespace named ${CLUSTERPOOL_TARGET_NAMESPACE} on ${HOST_URL}, validate your choice with 'oc get projects' and try again.${CLEAR}\n"
     exit 3
 fi
-printf "${GREEN}* Using $TARGET_NAMESPACE\n${CLEAR}"
+printf "${GREEN}* Using $CLUSTERPOOL_TARGET_NAMESPACE\n${CLEAR}"
 
 
 #----SELECT A CLUSTERCLAIM TO EXTRACT CREDENTIALS FROM----#
 if [[ "$CLUSTERCLAIM_NAME" == "" ]]; then
     # Prompt the user to choose a ClusterImageSet
-    clusterclaims=$(oc get clusterclaim -n ${TARGET_NAMESPACE})
+    clusterclaims=$(oc get clusterclaim -n ${CLUSTERPOOL_TARGET_NAMESPACE})
     clusterclaim_names=()
     i=0
     IFS=$'\n'
@@ -102,7 +102,7 @@ if [[ "$CLUSTERCLAIM_NAME" == "" ]]; then
         i=$((i+1))
     done;
     if [[ "$i" -lt 1 ]]; then
-        printf "${RED}No ClusterClaims found in the ${TARGET_NAMESPACE} namespace on ${HOST_URL}.  Please verify that ${TARGET_NAMESPACE} has ClusterClaims with 'oc get clusterclaim -n $TARGET_NAMESPACE' and try again.${CLEAR}\n"
+        printf "${RED}No ClusterClaims found in the ${CLUSTERPOOL_TARGET_NAMESPACE} namespace on ${HOST_URL}.  Please verify that ${CLUSTERPOOL_TARGET_NAMESPACE} has ClusterClaims with 'oc get clusterclaim -n $CLUSTERPOOL_TARGET_NAMESPACE' and try again.${CLEAR}\n"
         exit 3
     fi
     unset IFS
@@ -118,7 +118,7 @@ if [[ "$CLUSTERCLAIM_NAME" == "" ]]; then
 else
     oc get clusterclaim ${CLUSTERCLAIM_NAME} --no-headers &> /dev/null
     if [[ $? -ne 0 ]]; then
-        printf "${RED}Couldn't find a ClusterClaim named ${CLUSTERCLAIM_NAME} on ${HOST_URL} in the ${TARGET_NAMESPACE} namespace, validate your choice with 'oc get clusterclaim -n ${TARGET_NAMESPACE}' and try again.${CLEAR}\n"
+        printf "${RED}Couldn't find a ClusterClaim named ${CLUSTERCLAIM_NAME} on ${HOST_URL} in the ${CLUSTERPOOL_TARGET_NAMESPACE} namespace, validate your choice with 'oc get clusterclaim -n ${CLUSTERPOOL_TARGET_NAMESPACE}' and try again.${CLEAR}\n"
         exit 3
     fi
 fi
@@ -137,7 +137,7 @@ fi
 # Initialize loop variables
 CC_JSON=$CLUSTERCLAIM_NAME/.ClusterClaim.json
 CD_JSON=$CLUSTERCLAIM_NAME/.ClusterDeployment.json
-oc get clusterclaim ${CLUSTERCLAIM_NAME} -n ${TARGET_NAMESPACE} -o json > $CC_JSON
+oc get clusterclaim ${CLUSTERCLAIM_NAME} -n ${CLUSTERPOOL_TARGET_NAMESPACE} -o json > $CC_JSON
 CC_NS=`jq -r '.spec.namespace' $CC_JSON`
 if [[ "$CC_NS" != "null" ]]; then
     oc get clusterdeployment $CC_NS -n $CC_NS -o json > $CD_JSON

--- a/clusterclaims/templates/clusterclaim.lifetime.yaml.template
+++ b/clusterclaims/templates/clusterclaim.lifetime.yaml.template
@@ -2,7 +2,7 @@ apiVersion: hive.openshift.io/v1
 kind: ClusterClaim
 metadata:
   name: __CLUSTERCLAIM_NAME__
-  namespace: __TARGET_NAMESPACE__
+  namespace: __CLUSTERPOOL_TARGET_NAMESPACE__
 spec:
   clusterPoolName: __CLUSTERPOOL_NAME__
   lifetime: __CLUSTERCLAIM_LIFETIME__

--- a/clusterclaims/templates/clusterclaim.nolifetime.yaml.template
+++ b/clusterclaims/templates/clusterclaim.nolifetime.yaml.template
@@ -2,6 +2,6 @@ apiVersion: hive.openshift.io/v1
 kind: ClusterClaim
 metadata:
   name: __CLUSTERCLAIM_NAME__
-  namespace: __TARGET_NAMESPACE__
+  namespace: __CLUSTERPOOL_TARGET_NAMESPACE__
 spec:
   clusterPoolName: __CLUSTERPOOL_NAME__

--- a/clusterpools/templates/clusterpool.aws.yaml.template
+++ b/clusterpools/templates/clusterpool.aws.yaml.template
@@ -2,7 +2,7 @@ apiVersion: hive.openshift.io/v1
 kind: ClusterPool
 metadata:
   name: __CLUSTERPOOL_NAME__
-  namespace: __TARGET_NAMESPACE__
+  namespace: __CLUSTERPOOL_TARGET_NAMESPACE__
 spec:
   baseDomain: __CLUSTERPOOL_AWS_BASE_DOMAIN__
   imageSetRef:

--- a/clusterpools/templates/clusterpool.azure.yaml.template
+++ b/clusterpools/templates/clusterpool.azure.yaml.template
@@ -2,7 +2,7 @@ apiVersion: hive.openshift.io/v1
 kind: ClusterPool
 metadata:
   name: __CLUSTERPOOL_NAME__
-  namespace: __TARGET_NAMESPACE__
+  namespace: __CLUSTERPOOL_TARGET_NAMESPACE__
 spec:
   baseDomain: __CLUSTERPOOL_AZURE_BASE_DOMAIN__
   imageSetRef:

--- a/clusterpools/templates/clusterpool.gcp.yaml.template
+++ b/clusterpools/templates/clusterpool.gcp.yaml.template
@@ -2,7 +2,7 @@ apiVersion: hive.openshift.io/v1
 kind: ClusterPool
 metadata:
   name: __CLUSTERPOOL_NAME__
-  namespace: __TARGET_NAMESPACE__
+  namespace: __CLUSTERPOOL_TARGET_NAMESPACE__
 spec:
   baseDomain: __CLUSTERPOOL_GCP_BASE_DOMAIN__
   imageSetRef:


### PR DESCRIPTION
- Update `TARGET_NAMESPACE` to `CLUSTERPOOL_TARGET_NAMESPACE` due to conflict with the RHACM `deploy` variable
- Document `CLUSTERCLAIM_GROUP` and `CLUSTERCLAIM_LIFETIME`
- Add functionality to omit a lifetime by setting variable to "false"