### PR TITLE
Support Service Accounts ClusterClaims

### DIFF
--- a/clusterclaims/apply.sh
+++ b/clusterclaims/apply.sh
@@ -202,7 +202,7 @@ if [[ "$CLUSTERCLAIM_GROUP_NAME" == "" ]]; then
         # Prompt the user to choose an RBAC GROUP
         groups=$(oc get group -o=custom-columns=NAME:.metadata.name 2> /dev/null)
         if [[ "$?" != "0" ]]; then
-            printf "${BLUE}- It looks like you don't have any RBAC groups (our query errored).${CLEAR}\n"
+            printf "${BLUE}- It looks like you don't have access to any RBAC groups (our query errored).${CLEAR}\n"
             printf "${YELLOW}Enter the name of your RBAC group: ${CLEAR}"
             read CLUSTERCLAIM_GROUP_NAME
             if [ "$CLUSTERCLAIM_GROUP_NAME" == "" ]; then

--- a/clusterclaims/templates/clusterclaim.subject.serviceaccount.yaml.template
+++ b/clusterclaims/templates/clusterclaim.subject.serviceaccount.yaml.template
@@ -1,0 +1,4 @@
+  subjects:
+  - kind: ServiceAccount
+    name: '__RBAC_SERVICEACCOUNT_NAME__'
+    namespace: '__CLUSTERCLAIM_NAMESPACE__'

--- a/clusterclaims/templates/clusterclaim.subject.yaml.template
+++ b/clusterclaims/templates/clusterclaim.subject.yaml.template
@@ -1,4 +1,3 @@
-  subjects:
   - apiGroup: rbac.authorization.k8s.io
     kind: Group
     name: '__RBAC_GROUP_NAME__'


### PR DESCRIPTION
## Summary of Changes

This PR adds detection and support for Service Accounts in ClusterClaims.  When creating a ClusterClaim with a user of type Service Account, `lifeguard` will now automatically insert a subjects list with the service account to the ClusterClaim object to grant access to the checked out resources.  This support does not break support for RBAC groups - the user can still set an RBAC group as a Subject.  

### Misc. Changes - `--dry-run`
I've also added a "dry run" option which will generate the yaml for a claim, but not apply it!