### PR TITLE
Fix indentation of the subjects header when using only an RBAC Group

### DIFF
--- a/clusterclaims/apply.sh
+++ b/clusterclaims/apply.sh
@@ -239,7 +239,7 @@ if [[ "$CLUSTERCLAIM_GROUP_NAME" == "" ]]; then
         printf "${GREEN}* Using: $CLUSTERCLAIM_GROUP_NAME${CLEAR}\n"
         echo "" >> ./${CLUSTERCLAIM_NAME}/${CLUSTERCLAIM_NAME}.clusterclaim.yaml
         if [[ "$CLUSTERCLAIM_SERVICE_ACCOUNT" == "" ]]; then
-            echo "subjects:" >> ./${CLUSTERCLAIM_NAME}/${CLUSTERCLAIM_NAME}.clusterclaim.yaml
+            echo "  subjects:" >> ./${CLUSTERCLAIM_NAME}/${CLUSTERCLAIM_NAME}.clusterclaim.yaml
         fi
         ${SED} -e "s/__RBAC_GROUP_NAME__/$CLUSTERCLAIM_GROUP_NAME/g" ./templates/clusterclaim.subject.yaml.template >> ./${CLUSTERCLAIM_NAME}/${CLUSTERCLAIM_NAME}.clusterclaim.yaml
     fi
@@ -247,7 +247,7 @@ else
     printf "${GREEN}* Using: $CLUSTERCLAIM_GROUP_NAME${CLEAR}\n"
     echo "" >> ./${CLUSTERCLAIM_NAME}/${CLUSTERCLAIM_NAME}.clusterclaim.yaml
     if [[ "$CLUSTERCLAIM_SERVICE_ACCOUNT" == "" ]]; then
-        echo "subjects:" >> ./${CLUSTERCLAIM_NAME}/${CLUSTERCLAIM_NAME}.clusterclaim.yaml
+        echo "  subjects:" >> ./${CLUSTERCLAIM_NAME}/${CLUSTERCLAIM_NAME}.clusterclaim.yaml
     fi
     ${SED} -e "s/__RBAC_GROUP_NAME__/$CLUSTERCLAIM_GROUP_NAME/g" ./templates/clusterclaim.subject.yaml.template >> ./${CLUSTERCLAIM_NAME}/${CLUSTERCLAIM_NAME}.clusterclaim.yaml
 fi


### PR DESCRIPTION
## Summary of Changes

In our previous ServiceAccount update, we introduced a few new code flows (no rbac group, rbac group and no sa, sa and no rbac group, both rbac group and sa).  As a result we included the `subjects:` header in the claim yaml template for the service account and injected the line if the RBAC group was used without service accounts.  The injected `subjects:` header didn't include indentation, which caused malformed yaml for the claim in the "rbac group and no sa" case.  This resolves that issue.  