### PR TITLE
Add Documentation for ServiceAccount and RBAC Group Creation/Management

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,17 +14,17 @@ If you don't want colorized output or are using automation/a shell that can't sh
 
 ### Advanced Cluster Management/Hive Installation
 
-If you want to use ClusterPools (the primary focus of this repo), you'll first need a Kubernetes cluster running [Hive](https://github.com/openshift/hive) v1.0.13+ or [Red Hat Advanced Cluster Managment for Kubernetes (RHACM)](https://www.redhat.com/en/technologies/management/advanced-cluster-management) 2.1.0+ (which includes a productized version of hive).  Some of the features exposed in this utility are only present in Hive v1.0.16+ and RHACM 2.2.0+, but older versions won't break this utility, just some features may not work!  Both Hive and ACM can be installed via OperatorHub on OpenShift but you can also build and install Hive from source and the RHACM team is iterating on an installable open source project as well under the [open-cluster-management organization on GitHub](https://github.com/open-cluster-management).  
+If you want to use ClusterPools (the primary focus of this repo), you'll first need a Kubernetes cluster running [Hive](https://github.com/openshift/hive) v1.0.13+ or [Red Hat Advanced Cluster Managment for Kubernetes (RHACM)](https://www.redhat.com/en/technologies/management/advanced-cluster-management) 2.1.0+ (which includes a productized version of hive).  Some of the features exposed in this utility are only present in Hive v1.0.16+ and RHACM 2.2.0+, but older versions won't break this utility, just some features may not work!  Both Hive and RHACM can be installed via OperatorHub on OpenShift but you can also build and install Hive from source and the RHACM team is iterating on an installable open source project as well under the [open-cluster-management organization on GitHub](https://github.com/open-cluster-management).  
 
 ### Optional: Configuring RBAC
 
-Once you have a cluster, we recommend that you configure RBAC groups and/or Service Accounts to federate access to your ClusterPools and ClusterDeployments.  These Kubernetes resources represent OpenShift clusters and the lifecycle of these Kube resources determines the state of those OpenShift clusters, so it is important to restrict access to these resources especially when used in automation. 
+Once you have a cluster, we recommend that you configure RBAC groups and/or Service Accounts to federate access to your ClusterPools and ClusterDeployments.  These Kubernetes resources represent OpenShift clusters and the lifecycle of these Kubernetes resources determines the state of those OpenShift clusters, so it is important to restrict access to these resources especially when used in automation. 
 
 We have some documentation and resources to help you make the best choices around RBAC for ClusterPools derived from our own experience using ClusterPools on RHACM to serve multitenant users (internal dev squads, not true multitenancy) and at scale within CI scenarios.  Our resources can be found in the `docs` directory of this repo, individual documents linked below:
-* [Creating RBAC Gropus and Setting up the Group Sync Operator](docs/creating_rbac_groups_and_groupsync.md)
+* [Creating RBAC Groups and Setting up the Group Sync Operator](docs/creating_rbac_groups_and_groupsync.md)
 * [Creating and Using Service Accounts for CI](docs/creating_and_using_service_accounts_for_CI.md)
 
-## Creating and Consuming Clusterpools
+## Creating and Consuming ClusterPools
 
 ### ClusterPools
 
@@ -85,6 +85,21 @@ CLUSTERCLAIM_GROUP_NAME - RBAC group to associate with the ClusterClaim
 CLUSTERCLAIM_LIFETIME - lifetime for the cluster claim before automatic deletion, formatted as `1h2m3s` omitting units as desired (set to "false" to disable)
 ```
 **Note:** If you find that the above list does not fully automate clusterclaim creation, then we made a mistake or need to update the list!  Please let us know via a GitHub issue or contribute a patch! 
+
+#### Configuring Your `subjects` List Correctly
+
+We overview [how we use RBAC Groups](docs/creating_rbac_groups_and_groupsync.md) and [ServiceAccounts](docs/creating_and_using_service_accounts_for_CI.md) in their own documents, but we'll overview the `subjects` list in the ClusterClaim object briefly here, as it pertains to the use of `lifeguard`.  
+
+The `subjects` array in the ClusterClaim defines a list of RBAC entities who should be granted access to the claimed cluster and its related resources including the ClusterDeployment, User/Pass Secrets, and kubeconfig secret.  Hive will automatically grant RBAC entities in this list access to the claimed clusters' resources.  `lifeguard` handles the population of this list by:
+* Automatically detecting if the user who called `lifeguard` is a ServiceAccount type user and adding that ServiceAccount to the `subjects` array
+* Prompting the user to enter an RBAC Group to add to the `subjects` array - this is usually used to add the users' own RBAC group (in our case the users' team) to the claim.  
+
+You can also add individual users, ServiceAccounts, and all ServiceAccounts in a given namespace to a claim but these operations aren't exposed in `lifeguard` yet, but we're open to requests and contributions!  
+
+If you see the following error, you likely have a misconfigured `subjects` array and haven't been granted permissions to read your claimed clusters' credentials:
+```
+Error from server (Forbidden): secrets "<clusterdeployment-name>-<identifier>-admin-password" is forbidden: User "<username>" cannot get resource "secrets" in API group "" in the namespace "<clusterdeployment-name>"
+```
 
 #### Getting Credentials for a Claimed Cluster
 `apply.sh` will extract the credentials for the cluster you claimed and tell you how to access those credentials but, if you have a pre-existing claim, we have a utility script to handle _just_ credential extraction.  

--- a/README.md
+++ b/README.md
@@ -10,11 +10,26 @@ Welcome to the Open Cluster Management _Lifeguard_ project.  _Lifeguard_ provide
 
 If you don't want colorized output or are using automation/a shell that can't show bash colorization, `export COLOR=False` for non-colorized output.  
 
-## ClusterPools
+## Prereqs
+
+### Advanced Cluster Management/Hive Installation
+
+If you want to use ClusterPools (the primary focus of this repo), you'll first need a Kubernetes cluster running [Hive](https://github.com/openshift/hive) v1.0.13+ or [Red Hat Advanced Cluster Managment for Kubernetes (RHACM)](https://www.redhat.com/en/technologies/management/advanced-cluster-management) 2.1.0+ (which includes a productized version of hive).  Some of the features exposed in this utility are only present in Hive v1.0.16+ and RHACM 2.2.0+, but older versions won't break this utility, just some features may not work!  Both Hive and ACM can be installed via OperatorHub on OpenShift but you can also build and install Hive from source and the RHACM team is iterating on an installable open source project as well under the [open-cluster-management organization on GitHub](https://github.com/open-cluster-management).  
+
+### Optional: Configuring RBAC
+
+Once you have a cluster, we recommend that you configure RBAC groups and/or Service Accounts to federate access to your ClusterPools and ClusterDeployments.  These Kubernetes resources represent OpenShift clusters and the lifecycle of these Kube resources determines the state of those OpenShift clusters, so it is important to restrict access to these resources especially when used in automation. 
+
+We have some documentation and resources to help you make the best choices around RBAC for ClusterPools derived from our own experience using ClusterPools on RHACM to serve multitenant users (internal dev squads, not true multitenancy) and at scale within CI scenarios.  Our resources can be found in the `docs` directory of this repo, individual documents linked below:
+* 
+
+## Creating and Consuming Clusterpools
+
+### ClusterPools
 
 The [ClusterPool submodule of this project](/clusterpools) provides an "easy way" to create your first ClusterPool on a target cluster.  
 
-### Creating a ClusterPool
+#### Creating a ClusterPool
 
 To create your first ClusterPool:
 1. `oc login` to the OCM/ACM/Hive cluster where you wish to host ClusterPools
@@ -43,7 +58,7 @@ CLUSTERPOOL_GCP_BASE_DOMAIN - gcp base domain to use for your clusterpool
 ```
 **Note:** If you find that the above list does not fully automate clusterpool creation, then we made a mistake or need to update the list!  Please let us know via a GitHub issue or contribute a patch! 
 
-### Destroying a ClusterPool
+#### Destroying a ClusterPool
 
 To delete a ClusterPool:
 **Note:** Deleting a ClusterPool will delete all *unclaimed* clusters in the pool, but any claimed clusters (clusters with an associated ClusterClaim) will remain until the ClusterClaim is deleted.  You can check which ClusterPool a ClusterClaim is associated with by checking the `spec.clusterPoolName` entry in the ClusterClaim object via `oc get ClusterClaim <cluster-claim-name> -n <namespace> -o json | jq '.spec.clusterPoolName'`.  
@@ -51,9 +66,9 @@ To delete a ClusterPool:
 2. `cd clusterpools` and run `delete.sh` (named for the `oc` command it will leverage)
 3. Follow the prompts, the script will guide you through the location and deletion of your ClusterPool
 
-## ClusterClaims
+### ClusterClaims
 
-### Claiming a Cluster from a ClusterPool (Creating a ClusterClaim)
+#### Claiming a Cluster from a ClusterPool (Creating a ClusterClaim)
 
 To claim a cluster from a ClusterPool:
 1. `oc login` to the OCM/ACM/Hive cluster where you created your clusterpools
@@ -70,7 +85,7 @@ CLUSTERCLAIM_LIFETIME - lifetime for the cluster claim before automatic deletion
 ```
 **Note:** If you find that the above list does not fully automate clusterclaim creation, then we made a mistake or need to update the list!  Please let us know via a GitHub issue or contribute a patch! 
 
-### Getting Credentials for a Claimed Cluster
+#### Getting Credentials for a Claimed Cluster
 `apply.sh` will extract the credentials for the cluster you claimed and tell you how to access those credentials but, if you have a pre-existing claim, we have a utility script to handle _just_ credential extraction.  
 
 To extract the creentials from a pre-existing claim:
@@ -78,7 +93,7 @@ To extract the creentials from a pre-existing claim:
 2. `cd clusterclaims` and run `get_credentials.sh` (named for the `oc` command it will leverage throughout, `get`)
 3. Follow the prompts, the script will guide you through the credentials extraction
 
-### Destroying a ClusterClaim and the Claimed Cluster
+#### Destroying a ClusterClaim and the Claimed Cluster
 
 To delete a ClusterClaim:
 **Note:** Deleting a ClusterClaim immediately deletes the cluster that was allocated to the claim.  You can view the claimed cluster via `oc get clusterclaim <cluster-claim-name> -n <namespace> -o json | jq -r '.spec.namespace'`.  

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ If you want to use ClusterPools (the primary focus of this repo), you'll first n
 Once you have a cluster, we recommend that you configure RBAC groups and/or Service Accounts to federate access to your ClusterPools and ClusterDeployments.  These Kubernetes resources represent OpenShift clusters and the lifecycle of these Kube resources determines the state of those OpenShift clusters, so it is important to restrict access to these resources especially when used in automation. 
 
 We have some documentation and resources to help you make the best choices around RBAC for ClusterPools derived from our own experience using ClusterPools on RHACM to serve multitenant users (internal dev squads, not true multitenancy) and at scale within CI scenarios.  Our resources can be found in the `docs` directory of this repo, individual documents linked below:
-* 
+* [Creating RBAC Gropus and Setting up the Group Sync Operator](docs/creating_rbac_groups_and_groupsync.md)
+* [Creating and Using Service Accounts for CI](docs/creating_and_using_service_accounts_for_CI.md)
 
 ## Creating and Consuming Clusterpools
 

--- a/docs/creating_and_using_service_accounts_for_CI.md
+++ b/docs/creating_and_using_service_accounts_for_CI.md
@@ -1,0 +1,142 @@
+# Creating and Using Service Accounts for ClusterPools in CI/Automation
+
+One of the primary use-cases of Clusterpools is to provide environments rapidly on-demand for CI with pre-configured security constraints, ICSPs, sizing, etc.  Clusterpools outsource the difficult, time consuming, expensive, and error-prone provisioning problem to ACM/Hive and provide an easy interface to acquire Clusters.  We use ClusterPools to drive our CI at scale (up to 72 clusters consumed by our integration tests per day).  
+
+But - how do you interface with the cluster hosting your ClusterPools if you use token-based identity providers like GitHub?  We recommend that you use ServiceAccounts with some custom ClusterRoles and ClusterRoleBindings.  Service accounts provide token-based authentication for CI systems to use to access ClusterPools. 
+
+## Note on ServiceAccount "Groups"
+
+If you would like to give all service accounts in a given namespace access to clusterpools/clusterpool resources, you can optionally replace the ServiceAccount `subjects` list entries found in the following sections with a 'group' as follows:
+```
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:serviceaccounts:__SERVICE_ACCOUNT_NAMESPACE__'
+```
+
+## Creating a Service Account and Configuring Roles
+
+The below yaml is a one-stop-shop for creating the necessary ClusterRoles, ServiceAccount, and ClusterRoleBindings for a clusterpool (after filling in the template items).  The following will create:
+
+**Custom ClusterRole**
+    - grants access to create/delete ClusterClaims (in order to claim clusters from our pools)
+
+**ClusterRoleBindings**
+    - `clusterpool-user` for access to create/delete clusterpools and claims
+    - `view` to view the project that holds our clusterpools
+    - `hive-cluster-pool-user` to [propogate permissions from pools in the namespace to the ClusterProvision/Deployment namespaces for provision failure debugging](https://github.com/openshift/hive/blob/master/docs/clusterpools.md#managing-admins-for-cluster-pools) (_technically optional_)
+
+```
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: clusterpool-user
+rules:
+  - apiGroups:
+      - 'hive.openshift.io'
+    resources:
+      - clusterclaims
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - delete
+  - apiGroups:
+      - 'hive.openshift.io'
+    resources:
+      - clusterpools
+    verbs:
+      - get
+      - watch
+      - list
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: __SERVICE_ACCOUNT_NAME__
+  namespace: __SERVICE_ACCOUNT_NAMESPACE__
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: __SERVICE_ACCOUNT_NAME__-clusterpool-user
+  namespace: __SERVICE_ACCOUNT_NAMESPACE__
+subjects:
+  - kind: ServiceAccount
+    namespace: __SERVICE_ACCOUNT_NAMESPACE__
+    name: __SERVICE_ACCOUNT_NAME__
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: clusterpool-user
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: __SERVICE_ACCOUNT_NAME__-view
+  namespace: __SERVICE_ACCOUNT_NAMESPACE__
+subjects:
+  - kind: ServiceAccount
+    namespace: __SERVICE_ACCOUNT_NAMESPACE__
+    name: __SERVICE_ACCOUNT_NAME__
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: __SERVICE_ACCOUNT_NAME__-cluster-pool-admin
+  namespace: __SERVICE_ACCOUNT_NAMESPACE__
+subjects:
+  - kind: ServiceAccount
+    namespace: __SERVICE_ACCOUNT_NAMESPACE__
+    name: __SERVICE_ACCOUNT_NAME__
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: hive-cluster-pool-admin
+```
+
+## Extracting the Token for Your Service Account
+
+Once you've created a service account, you should be able to find the service account via:
+```
+gbuchana-mac:lifeguard gurnben$ oc get sa -n <sa-namespace> <sa-name>
+NAME                  SECRETS   AGE
+<sa-name>             2         5d23h
+```
+and extract the service accounts token via:
+```
+gbuchana-mac:lifeguard gurnben$ oc sa get-token -n <sa-namespace> <sa-name>
+REDACTED
+```
+
+This token doesn't expire and can be used in your CI use-cases.  The token should regenerate if you delete the secret containing the token.  
+
+## Usintg Your SA to Claim Clusters
+
+You can log in to your cluster as your service account by using the `--token=` option:
+```
+oc login --token=<sa-token> api.<cluster-name>.<domain>:6443
+```
+and check that you're logged in as your SA user:
+```
+gbuchana-mac:lifeguard gurnben$ oc whoami
+system:serviceaccount:<sa-namespace>:<sa-name>
+```
+
+If you're using the lifeguard project to claim clusters from your pool - it will automatically detect if you're using a user of type "serviceaccount" (internally it runs an `oc whoami`) and will automatically add the ServiceAccount to the `subjects` list.  That being said, you can manually add groups and/or ServiceAccounts to your ClusterClaims as follows:
+```
+  subjects:
+  - kind: ServiceAccount
+    name: '__RBAC_SERVICEACCOUNT_NAME__'
+    namespace: '__CLUSTERCLAIM_NAMESPACE__'
+  - apiGroup: rbac.authorization.k8s.io
+    kind: Group
+    name: '__RBAC_GROUP_NAME__'
+```
+
+As logn as the ServiceAccount is in the `subjects` list - ACM/Hive wil give the ServiceAccount permission to read the ClusterDeployment and credentials secrets for the cluster you've checked out.  

--- a/docs/creating_and_using_service_accounts_for_CI.md
+++ b/docs/creating_and_using_service_accounts_for_CI.md
@@ -1,8 +1,8 @@
 # Creating and Using Service Accounts for ClusterPools in CI/Automation
 
-One of the primary use-cases of Clusterpools is to provide environments rapidly on-demand for CI with pre-configured security constraints, ICSPs, sizing, etc.  Clusterpools outsource the difficult, time consuming, expensive, and error-prone provisioning problem to ACM/Hive and provide an easy interface to acquire Clusters.  We use ClusterPools to drive our CI at scale (up to 72 clusters consumed by our integration tests per day).  
+One of the primary use-cases of ClusterPools is to provide environments rapidly on-demand for CI with pre-configured security constraints, ImageContentSourcePolicies, sizing, etc.  ClusterPools outsource the difficult, time consuming, expensive, and error-prone provisioning problem to ACM/Hive and provide an easy interface to acquire Clusters.  We use ClusterPools to drive our CI at scale (up to 72 clusters consumed by our integration tests per day).  
 
-But - how do you interface with the cluster hosting your ClusterPools if you use token-based identity providers like GitHub?  We recommend that you use ServiceAccounts with some custom ClusterRoles and ClusterRoleBindings.  Service accounts provide token-based authentication for CI systems to use to access ClusterPools. 
+But - how do you interface with the cluster hosting your ClusterPools if you use token-based identity providers like GitHub?  We recommend that you use ServiceAccounts with some custom ClusterRoles and RoleBindings.  Service accounts provide token-based authentication for CI systems to use to access ClusterPools. 
 
 ## Note on ServiceAccount "Groups"
 
@@ -16,12 +16,12 @@ subjects:
 
 ## Creating a Service Account and Configuring Roles
 
-The below yaml is a one-stop-shop for creating the necessary ClusterRoles, ServiceAccount, and ClusterRoleBindings for a clusterpool (after filling in the template items).  The following will create:
+The below yaml is a one-stop-shop for creating the necessary ClusterRoles, ServiceAccount, and RoleBindings for a clusterpool (after filling in the template items).  The following will create:
 
 **Custom ClusterRole**
     - grants access to create/delete ClusterClaims (in order to claim clusters from our pools)
 
-**ClusterRoleBindings**
+**RoleBindings**
     - `clusterpool-user` for access to create/delete clusterpools and claims
     - `view` to view the project that holds our clusterpools
     - `hive-cluster-pool-user` to [propogate permissions from pools in the namespace to the ClusterProvision/Deployment namespaces for provision failure debugging](https://github.com/openshift/hive/blob/master/docs/clusterpools.md#managing-admins-for-cluster-pools) (_technically optional_)
@@ -57,7 +57,7 @@ metadata:
   name: __SERVICE_ACCOUNT_NAME__
   namespace: __SERVICE_ACCOUNT_NAMESPACE__
 ---
-kind: ClusterRoleBinding
+kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: __SERVICE_ACCOUNT_NAME__-clusterpool-user
@@ -71,7 +71,7 @@ roleRef:
   kind: ClusterRole
   name: clusterpool-user
 ---
-kind: ClusterRoleBinding
+kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: __SERVICE_ACCOUNT_NAME__-view
@@ -85,7 +85,7 @@ roleRef:
   kind: ClusterRole
   name: view
 ---
-kind: ClusterRoleBinding
+kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: __SERVICE_ACCOUNT_NAME__-cluster-pool-admin
@@ -104,27 +104,27 @@ roleRef:
 
 Once you've created a service account, you should be able to find the service account via:
 ```
-gbuchana-mac:lifeguard gurnben$ oc get sa -n <sa-namespace> <sa-name>
+$ oc get sa -n <sa-namespace> <sa-name>
 NAME                  SECRETS   AGE
 <sa-name>             2         5d23h
 ```
 and extract the service accounts token via:
 ```
-gbuchana-mac:lifeguard gurnben$ oc sa get-token -n <sa-namespace> <sa-name>
+$ oc sa get-token -n <sa-namespace> <sa-name>
 REDACTED
 ```
 
 This token doesn't expire and can be used in your CI use-cases.  The token should regenerate if you delete the secret containing the token.  
 
-## Usintg Your SA to Claim Clusters
+## Using Your ServiceAccount to Claim Clusters
 
 You can log in to your cluster as your service account by using the `--token=` option:
 ```
 oc login --token=<sa-token> api.<cluster-name>.<domain>:6443
 ```
-and check that you're logged in as your SA user:
+and check that you're logged in as your ServiceAccount user:
 ```
-gbuchana-mac:lifeguard gurnben$ oc whoami
+$ oc whoami
 system:serviceaccount:<sa-namespace>:<sa-name>
 ```
 
@@ -139,4 +139,4 @@ If you're using the lifeguard project to claim clusters from your pool - it will
     name: '__RBAC_GROUP_NAME__'
 ```
 
-As logn as the ServiceAccount is in the `subjects` list - ACM/Hive wil give the ServiceAccount permission to read the ClusterDeployment and credentials secrets for the cluster you've checked out.  
+As long as the ServiceAccount is in the `subjects` list - ACM/Hive will give the ServiceAccount permission to read the ClusterDeployment and credentials secrets for the cluster you've checked out.  

--- a/docs/creating_rbac_groups_and_groupsync.md
+++ b/docs/creating_rbac_groups_and_groupsync.md
@@ -1,0 +1,81 @@
+# Configuring RBAC Groups and GroupSync
+
+One of the primary use-cases of Clusterpools is to provide dev/test environments with pre-configured security constraints, ICSPs, sizing, etc at scale across a development organization.  Clusterpools can provide these environments efficiently, quickly, and at scale to developers - eliminating the common issue of generating development environments and, when combined with [tools to toggle hibernation](https://www.openshift.com/blog/hibernate-for-cost-savings-for-advanced-cluster-management-provisioned-clusters-with-subscriptions), it can also represent a reduction in cost for development environments. 
+
+To achieve this effectiely in our experience, we needed to have development squads share access to a common "Clusterpool Host" Hub cluster with sufficient permissions to create/consume/delete clusterpools without interfering with one anothers' resources or leaking credentials cross-squad.  We accomplish this encapsulation by granting squads namespace-scoped access with each squad owning and operating within a single namespace.  This can be accomplished by creating and allocated a few roles, overviewed below.   
+
+We mirror/generate these RBAC groups from our `open-cluster-management` GitHub organization using the [group-sync operator](https://github.com/redhat-cop/group-sync-operator) after configuring a GitHub OAuth Provider on the cluster, which we'll also overview below.  
+
+## "Multitenancy" via Namespace-Scoped RBAC Roles
+
+When it comes to our internal development squads, we will sometimes take the "easy route" and allocate each sqaud (represented as an RBAC group in OpenShift mirrored from GitHub via group-sync) a namespace and give the group `cluster-admin` within that namespace, but we don't recommend that most users give anyone `cluster-admin`, even on a namespace.  Instead, we recommend allocating `create` and `delete` access sparingly.  
+
+We recommend that you create a namespace for each rbac group and grant the group the standard openshift view role and a custom clusterpool-focused role on that namespace using the ClusterRole and ClusterRoleBindings below:
+
+Custom ClusterRole - grants access to create/delete clusterpools, claims, and deployments as well as secrets (required for cloud platform creds and install-configs):
+```
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: clusterpool-user
+rules:
+  - apiGroups:
+      - 'hive.openshift.io'
+    resources:
+      - clusterclaims
+      - clusterdeployments
+      - clusterpools
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - delete
+  - apiGroups:
+      - ''
+    resources:
+      - secrets
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - delete
+```
+
+ClusterRoleBindings:
+```
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: <your-crb-name>
+  namespace: <group-namespace>
+subjects:
+  - kind: <one of: ServiceAccount,User,Group>
+    name: <group-name>
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: clusterpool-user
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: <your-crb-name>
+  namespace: <group-namespace>
+subjects:
+  - kind: <one of: ServiceAccount,User,Group>
+    name: <group-name>
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+```
+
+You can re-use the ClusterRole (`clusterpool-user`) bound to different namespaces for different groups - that way if you ever need to expand permissions, you only have to change the role in one place.  
+
+### Note on the `subjects` List in ClusterClaims and Debugging Failed Provisions
+
+ClusterPools provision each cluster in their own namespace, housing the associated CluterProvision, ClusterDeployment, ClusterDeprovision, etc. objects in that namespace as well as the secrets holding teh password and kubeconfig for any successfully provisioned cluster.  Because all of this information is housed in another namespace, the ClusterRole and ClusterRoleBindings listed above won't give users access to the ClusterDeployment, associated secrets (user/pass), or the Cluster provision logs for any cluster created by their ClusterPool unless they claim a cluster from that pool and properly populate the `subjects` list of the ClusterClaim with their RBAC group or ServiceAccounts' name.  If the user provides RBAC targets in the subjects array, hive will allow the targets to view the claimed ClusterDeployment and Secrets.  However, users configured with the above roles and rolebindings will _not_ be able to see install logs for their ClusterPool clusters, so if they hit a quota or configuration issue, the admin will have to step in to provide debugging information.  The Hive and ACM teams are working on a resolution which will allow ClusterPools to propagate permissions to ClusterProvisions similar to the propagation seen with claims.  
+
+`lifeguard` automatically prompts the user to enter an rbac group name if desired and automatically detects and adds a ServiceAccount name if `lifegaurd` was invoked by a service account.  


### PR DESCRIPTION
## Summary of Changes

Now that we've planned an executed on RBAC configurations based around creating and maintaining clusterpools for multitenant (RBAC Groups) and CI (ServiceAccounts) use cases - we should document these rbac roles, groups, etc. and how to implement a similar model.  This PR includes such documents!