### PR TITLE
Add a basic oc extension install/uninstall

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,28 @@
+.PHONY: install-oc-extension
+## install the lifegaurd project as an oc extension
+install-oc-extension:
+	@cp $(PWD)/clusterpools/apply.sh /usr/local/bin/oc-clusterpool_create
+	@echo "Added an oc extension for 'oc clusterpool-create'"
+	@cp $(PWD)/clusterpools/delete.sh /usr/local/bin/oc-clusterpool_delete
+	@echo "Added an oc extension for 'oc clusterpool-delete'"
+	@cp $(PWD)/clusterclaims/apply.sh /usr/local/bin/oc-clusterclaim_create
+	@echo "Added an oc extension for 'oc clusterclaim-create'"
+	@cp $(PWD)/clusterclaims/delete.sh /usr/local/bin/oc-clusterclaim_delete
+	@echo "Added an oc extension for 'oc clusterclaim-delete'"
+	@cp $(PWD)/clusterclaims/get_credentials.sh /usr/local/bin/oc-clusterclaim_get_credentials
+	@echo "Added an oc extension for 'oc clusterclaim-get-credentials'"
+
+.PHONY: uninstall-oc-extension
+## Uninstall the lifegaurd project as an oc extension
+uninstall-oc-extension:
+	@rm /usr/local/bin/oc-clusterpool_create
+	@echo "Removed the oc extension for 'oc clusterpool-create'"
+	@rm /usr/local/bin/oc-clusterpool_delete
+	@echo "Removed the oc extension for 'oc clusterpool-delete'"
+	@rm /usr/local/bin/oc-clusterclaim_create
+	@echo "Removed the oc extension for 'oc clusterclaim-create'"
+	@rm /usr/local/bin/oc-clusterclaim_delete
+	@echo "Removed the oc extension for 'oc clusterclaim-delete'"
+	@rm /usr/local/bin/oc-clusterclaim_get_credentials
+	@echo "Removed the oc extension for 'oc clusterclaim-get-credentials'"
+

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 .PHONY: install-oc-extension
 ## install the lifegaurd project as an oc extension
 install-oc-extension:
-	@cp $(PWD)/clusterpools/apply.sh /usr/local/bin/oc-clusterpool_create
-	@echo "Added an oc extension for 'oc clusterpool-create'"
+	@cp $(PWD)/clusterpools/apply.sh /usr/local/bin/oc-clusterpool_apply
+	@echo "Added an oc extension for 'oc clusterpool-apply'"
 	@cp $(PWD)/clusterpools/delete.sh /usr/local/bin/oc-clusterpool_delete
 	@echo "Added an oc extension for 'oc clusterpool-delete'"
-	@cp $(PWD)/clusterclaims/apply.sh /usr/local/bin/oc-clusterclaim_create
-	@echo "Added an oc extension for 'oc clusterclaim-create'"
+	@cp $(PWD)/clusterclaims/apply.sh /usr/local/bin/oc-clusterclaim_apply
+	@echo "Added an oc extension for 'oc clusterclaim-apply'"
 	@cp $(PWD)/clusterclaims/delete.sh /usr/local/bin/oc-clusterclaim_delete
 	@echo "Added an oc extension for 'oc clusterclaim-delete'"
 	@cp $(PWD)/clusterclaims/get_credentials.sh /usr/local/bin/oc-clusterclaim_get_credentials
@@ -15,12 +15,12 @@ install-oc-extension:
 .PHONY: uninstall-oc-extension
 ## Uninstall the lifegaurd project as an oc extension
 uninstall-oc-extension:
-	@rm /usr/local/bin/oc-clusterpool_create
-	@echo "Removed the oc extension for 'oc clusterpool-create'"
+	@rm /usr/local/bin/oc-clusterpool_apply
+	@echo "Removed the oc extension for 'oc clusterpool-apply'"
 	@rm /usr/local/bin/oc-clusterpool_delete
 	@echo "Removed the oc extension for 'oc clusterpool-delete'"
-	@rm /usr/local/bin/oc-clusterclaim_create
-	@echo "Removed the oc extension for 'oc clusterclaim-create'"
+	@rm /usr/local/bin/oc-clusterclaim_apply
+	@echo "Removed the oc extension for 'oc clusterclaim-apply'"
 	@rm /usr/local/bin/oc-clusterclaim_delete
 	@echo "Removed the oc extension for 'oc clusterclaim-delete'"
 	@rm /usr/local/bin/oc-clusterclaim_get_credentials

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Welcome to the Open Cluster Management _Lifeguard_ project.  _Lifeguard_ provide
 
 If you don't want colorized output or are using automation/a shell that can't show bash colorization, `export COLOR=False` for non-colorized output.  
 
+## Installing as an `oc` Extension
+
+You can easily install a basic version of `lifeguard` as an oc extension by running `make install-oc-extension`.  If you wish to uninstall these `oc` extensions at a later date - simply run `make uninstall-oc-extension`.  
+
 ## Prereqs
 
 ### Advanced Cluster Management/Hive Installation


### PR DESCRIPTION
## Summary of Changes

This PR adds a basic makefile to install/uninstall the scripts present in `lifeguard` as [oc plugins](https://docs.openshift.com/container-platform/4.6/cli_reference/openshift_cli/extending-cli-plugins.html).  