### PR TITLE
Use version sorting for images

### DIFF
--- a/clusterpools/apply.sh
+++ b/clusterpools/apply.sh
@@ -385,7 +385,7 @@ printf "${GREEN}* Using $OCP_PULL_SECRET\n${CLEAR}"
 #----SELECT OR CREATE CLUSTERIMAGESET----#
 if [[ "$CLUSTERIMAGESET_NAME" == "" ]]; then
     # Prompt the user to choose a ClusterImageSet
-    clusterimagesets=$(oc get clusterimagesets)
+    clusterimagesets=$(oc get clusterimagesets | sort -V)
     clusterimageset_names=()
     i=0
     IFS=$'\n'


### PR DESCRIPTION
I have no idea what witchcraft keeps the headings up top, but it's working, so...
```
* Using policy-grc-ocp-pull-secret
   	NAME                                                 RELEASE
. . .
(114)	img4.5.8-x86-64-appsub                               quay.io/openshift-release-dev/ocp-release:4.5.8-x86_64
(115)	img4.5.9-x86-64-appsub                               quay.io/openshift-release-dev/ocp-release:4.5.9-x86_64
(116)	img4.5.10-x86-64-appsub                              quay.io/openshift-release-dev/ocp-release:4.5.10-x86_64
(117)	img4.5.11-x86-64-appsub                              quay.io/openshift-release-dev/ocp-release:4.5.11-x86_64