### PR TITLE
Update logic to allow more clusters

### DIFF
--- a/clusterclaims/apply.sh
+++ b/clusterclaims/apply.sh
@@ -35,13 +35,23 @@ SHORTNAME=$(echo $USER | head -c 8)
 #----VALIDATE PREREQ----#
 # User needs to be logged into the cluster
 printf "${BLUE}* Testing connection${CLEAR}\n"
-HOST_URL=$(oc status | grep -o "https.*api.*")
-if [ $? -ne 0 ]; then
+if (! oc status &>/dev/null); then
     printf "${RED}ERROR: Make sure you are logged into an OpenShift Container Platform before running this script${CLEAR}\n"
     exit 2
 fi
-# Shorten to the basedomain and tell the user which cluster we're targetting
+HOST_URL=$(oc status | grep -o "https.*api.*")
+# Shorten to the basedomain and tell the user which cluster we're targeting
 HOST_URL=${HOST_URL/apps./}
+
+# If HOST_URL is empty, set to something generic
+if [[ -z "${HOST_URL}" ]]; then
+    if [[ -n "${KUBERNETES_SERVICE_HOST}" ]]; then
+        HOST_URL="<local-cluster>"
+    else
+        HOST_URL="<unspecifed-cluster>"
+    fi
+fi
+
 printf "${BLUE}* Using cluster: ${HOST_URL}${CLEAR}\n"
 VER=`oc version | grep "Server Version:"`
 printf "${BLUE}* ${VER}${CLEAR}\n"


### PR DESCRIPTION
My scenario is that I was running Lifeguard from inside a pod, in which case the URL will show up as an IP address.  I think making this check more generic will cover other use-cases I haven't considered also...

I'm not 100% sure about the `KUBERNETES_SERVICE_HOST` variable. Based on the [Kubernetes documentation](https://kubernetes.io/docs/tasks/access-application-cluster/access-cluster/#accessing-the-api-from-a-pod), we might need to update this to checking `kubernetes.default.svc` maybe? I don't think it really matters--we could just stick with `<unspecified-cluster>` and call it a day.