### PR TITLE
Hotfix regression in ClusterPool Object Check in ClusterClaims apply.sh

### DIFF
--- a/clusterclaims/apply.sh
+++ b/clusterclaims/apply.sh
@@ -143,7 +143,7 @@ while [[ "$CLUSTERPOOL_NAME" == "" ]]; do
         exit 3
     fi
 done
-oc get clusterpool ${CLUSTERPOOL_NAME} --no-headers &> /dev/null
+oc get clusterpool ${CLUSTERPOOL_NAME} -n ${CLUSTERPOOL_TARGET_NAMESPACE} --no-headers &> /dev/null
 if [[ $? -ne 0 ]]; then
     errorf "${RED}Couldn't find a ClusterPool named ${CLUSTERPOOL_NAME} on ${HOST_URL} in the ${CLUSTERPOOL_TARGET_NAMESPACE} namespace, validate your choice with 'oc get clusterpools -n ${CLUSTERPOOL_TARGET_NAMESPACE}' and try again.${CLEAR}\n"
     exit 3


### PR DESCRIPTION
## Summary of Changes

This one-line fix patches a regression introduced in a recent merge that removed a namespace argument from the clusterpool object validation in our clusterclaim creation logic.  This bug broke checkout on master.  