### PR TITLE
[hotfix] Update delete.sh to correctly target clusterclaim.hive instead of just clusterclaim

### DIFF
--- a/clusterclaims/delete.sh
+++ b/clusterclaims/delete.sh
@@ -121,7 +121,7 @@ if [[ "$CLUSTERCLAIM_NAME" == "" ]]; then
         exit 3
     fi
 else
-    oc get clusterclaim ${CLUSTERCLAIM_NAME} --no-headers &> /dev/null
+    oc get clusterclaim.hive ${CLUSTERCLAIM_NAME} --no-headers &> /dev/null
     if [[ $? -ne 0 ]]; then
         errorf "${RED}Couldn't find a ClusterClaim named ${CLUSTERCLAIM_NAME} on ${HOST_URL} in the ${CLUSTERPOOL_TARGET_NAMESPACE} namespace, validate your choice with 'oc get clusterclaim.hive -n ${CLUSTERPOOL_TARGET_NAMESPACE}' and try again.${CLEAR}\n"
         exit 3
@@ -143,7 +143,7 @@ if [[ ! ("$selection" == "Y" || "$selection" == "y") ]]; then
     printf "${GREEN} Deletion cancelled, exiting.${CLEAR}\n"
     exit 0
 else
-    oc delete clusterclaim -n $CLUSTERPOOL_TARGET_NAMESPACE $CLUSTERCLAIM_NAME
+    oc delete clusterclaim.hive -n $CLUSTERPOOL_TARGET_NAMESPACE $CLUSTERCLAIM_NAME
     if [[ "$?" -ne 0 ]]; then
         errorf "${RED}Failed to delete ClusterClaim $CLUSTERCLAIM_NAME, see above error message for more detail.${CLEAR}\n"
         exit 3

--- a/clusterpools/delete.sh
+++ b/clusterpools/delete.sh
@@ -122,7 +122,7 @@ fi
 printf "${GREEN}* Using: $CLUSTERPOOL_NAME${CLEAR}\n"
 
 #-----INFORM THE USER WHICH CLUSTERCLAIMS WOULD BE ORPHANED (WITHIN CLUSTERPOOL_TARGET_NAMESPACE)-----#
-clusterclaims=$(oc get clusterclaim -n $CLUSTERPOOL_TARGET_NAMESPACE -o json | jq --arg CLUSTERPOOLNAME "$CLUSTERPOOL_NAME" '.items[] | select(.spec.clusterPoolName==$CLUSTERPOOLNAME) | .metadata.name')
+clusterclaims=$(oc get clusterclaim.hive -n $CLUSTERPOOL_TARGET_NAMESPACE -o json | jq --arg CLUSTERPOOLNAME "$CLUSTERPOOL_NAME" '.items[] | select(.spec.clusterPoolName==$CLUSTERPOOLNAME) | .metadata.name')
 if [[ "$clusterclaims" != "" ]]; then
     printf "${YELLOW}The following ClusterClaims and their associated deployments will be orphaned if you delete $CLUSTERPOOL_NAME.${CLEAR}\n"
     i=1


### PR DESCRIPTION
## Summary of Changes

This hotfix will resolve an issue with delete.sh when used with an ACM 2.2+ cluster where the clusterclaim resource reference wasn't fully defined.  