### PR TITLE
Update azure install-config to default to an ACM hub-friendly config.

### DIFF
--- a/clusterpools/templates/install-config.azure.yaml.template
+++ b/clusterpools/templates/install-config.azure.yaml.template
@@ -17,7 +17,7 @@ compute:
   replicas: 3
   platform:
     azure:
-      type:  Standard_D2s_v3
+      type:  Standard_D4s_v3
       osDisk:
         diskSizeGB: 128
       zones:


### PR DESCRIPTION
## Summary of Changes

This change bumps the default worker instance type on Azure from 2vCPU/8GB RAM to 4vCPU/16GB RAM to allow Azure clusters with the default config to function as ACM hubs.  