### PR TITLE
Removing io1 and reducing storage size on azure to reduce costs for default config

### DIFF
--- a/clusterpools/templates/install-config.aws.yaml.template
+++ b/clusterpools/templates/install-config.aws.yaml.template
@@ -8,10 +8,6 @@ controlPlane:
   replicas: 3
   platform:
     aws:
-      rootVolume:
-        iops: 4000
-        size: 100
-        type: io1
       type: m5.xlarge
 compute:
 - hyperthreading: Enabled
@@ -19,10 +15,6 @@ compute:
   replicas: 3
   platform:
     aws:
-      rootVolume:
-        iops: 2000
-        size: 100
-        type: io1
       type: m5.xlarge
 networking:
   clusterNetwork:

--- a/clusterpools/templates/install-config.azure.yaml.template
+++ b/clusterpools/templates/install-config.azure.yaml.template
@@ -9,7 +9,7 @@ controlPlane:
   platform:
     azure:
       osDisk:
-        diskSizeGB: 128
+        diskSizeGB: 64
       type:  Standard_D4s_v3
 compute:
 - hyperthreading: Enabled
@@ -19,7 +19,7 @@ compute:
     azure:
       type:  Standard_D4s_v3
       osDisk:
-        diskSizeGB: 128
+        diskSizeGB: 64
       zones:
       - "1"
       - "2"


### PR DESCRIPTION
## Summary of Changes

This change drops the `io1` storage type to reduce cost on AWS and reduces the storage amount on Azure to reduce cost (but not by as much as dropping io1 as a default on AWS).  The user can still add these configurations manually, but they don't need to be in the default.  