### PR TITLE
Update owners file to unblock prow onboarding

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,13 +1,11 @@
 approvers:
 - gurnben
 - dhaiducek
-- mdelder
 - TheRealHaoLiu
 - KevinFCormier
 
 reviewers:
 - gurnben
 - dhaiducek
-- mdelder
 - TheRealHaoLiu
 - KevinFCormier


### PR DESCRIPTION
## Summary of Changes

This PR removes mdelder from the owners file to unblock [this PR](https://github.com/openshift/release/pull/19104#issuecomment-857010241) which drives OSCI Prow configuration for this repo.  