### PR TITLE
Fix errors validating install-configs when chosen as a secret

### DIFF
--- a/clusterpools/apply.sh
+++ b/clusterpools/apply.sh
@@ -654,8 +654,12 @@ if [[ "$YQ_INSTALLED" != "false" ]]; then
                     read selection
                     if [ "$selection" -lt "$i" ]; then
                         CLUSTERPOOL_INSTALL_CONFIG_SECRET_NAME=${secret_names[$(($selection-1))]}
+                        CLUSTERPOOL_INSTALL_CONFIG_SECRET=$CLUSTERPOOL_INSTALL_CONFIG_SECRET_NAME
+                        CLUSTERPOOL_INSTALL_CONFIG_FILE=./$CLUSTERPOOL_INSTALL_CONFIG_SECRET_NAME.yaml
+                        oc get secret -n $CLUSTERPOOL_TARGET_NAMESPACE $CLUSTERPOOL_INSTALL_CONFIG_SECRET_NAME -o json | jq -r '.data["install-config.yaml"]' | ${BASE64} -d > $CLUSTERPOOL_INSTALL_CONFIG_FILE
                         validate_installconfig_region
                         set_installconfig_skipmachinepools
+                        rm -f $CLUSTERPOOL_INSTALL_CONFIG_FILE
                     elif [ "$selection" -eq "$new" ]; then
                         generate_installconfigsecret
                     else

--- a/clusterpools/apply.sh
+++ b/clusterpools/apply.sh
@@ -654,9 +654,8 @@ if [[ "$YQ_INSTALLED" != "false" ]]; then
                     read selection
                     if [ "$selection" -lt "$i" ]; then
                         CLUSTERPOOL_INSTALL_CONFIG_SECRET_NAME=${secret_names[$(($selection-1))]}
-                        CLUSTERPOOL_INSTALL_CONFIG_SECRET=$CLUSTERPOOL_INSTALL_CONFIG_SECRET_NAME
                         CLUSTERPOOL_INSTALL_CONFIG_FILE=./$CLUSTERPOOL_INSTALL_CONFIG_SECRET_NAME.yaml
-                        oc get secret -n $CLUSTERPOOL_TARGET_NAMESPACE $CLUSTERPOOL_INSTALL_CONFIG_SECRET_NAME -o json | jq -r '.data["install-config.yaml"]' | ${BASE64} -d > $CLUSTERPOOL_INSTALL_CONFIG_FILE
+                        oc get secret -n $CLUSTERPOOL_TARGET_NAMESPACE $CLUSTERPOOL_INSTALL_CONFIG_SECRET_NAME -o json | jq -r '.data["install-config.yaml"]' | ${BASE64} --decode > $CLUSTERPOOL_INSTALL_CONFIG_FILE
                         validate_installconfig_region
                         set_installconfig_skipmachinepools
                         rm -f $CLUSTERPOOL_INSTALL_CONFIG_FILE


### PR DESCRIPTION
## Summary of Changes

This change extracts a secret for install-config region validation if a pre-existing secret is chosen for the install-config.  

Previously, if you set a region and chose a custom install config from the list of secrets (not creating a new secret), lifeguard would error out because it was unable to find the install-config file.  