### PR TITLE
fix: deprecated oc status warnings

### DIFF
--- a/clusterclaims/apply.sh
+++ b/clusterclaims/apply.sh
@@ -44,11 +44,11 @@ CLUSTERCLAIM_AUTO_IMPORT=${CLUSTERCLAIM_AUTO_IMPORT:-"false"}
 #----VALIDATE PREREQ----#
 # User needs to be logged into the cluster
 printf "${BLUE}* Testing connection${CLEAR}\n"
-if (! oc status &>/dev/null); then
+if (! oc whoami --show-server &>/dev/null); then
     errorf "${RED}ERROR: Make sure you are logged into an OpenShift Container Platform before running this script${CLEAR}\n"
     exit 2
 fi
-HOST_URL=$(oc status | grep -o "https.*api.*")
+HOST_URL=$(oc whoami --show-server 2>/dev/null)
 # Shorten to the basedomain and tell the user which cluster we're targeting
 HOST_URL=${HOST_URL/apps./}
 

--- a/clusterclaims/delete.sh
+++ b/clusterclaims/delete.sh
@@ -37,7 +37,7 @@ fi
 #----VALIDATE PREREQ----#
 # User needs to be logged into the cluster
 printf "${BLUE}* Testing connection${CLEAR}\n"
-HOST_URL=$(oc status | grep -o "https.*api.*")
+HOST_URL=$(oc whoami --show-server 2>/dev/null)
 if [ $? -ne 0 ]; then
     errorf "${RED}ERROR: Make sure you are logged into an OpenShift Container Platform before running this script${CLEAR}\n"
     exit 2

--- a/clusterclaims/get_credentials.sh
+++ b/clusterclaims/get_credentials.sh
@@ -37,7 +37,7 @@ fi
 #----VALIDATE PREREQ----#
 # User needs to be logged into the cluster
 printf "${BLUE}* Testing connection${CLEAR}\n"
-HOST_URL=$(oc status | grep -o "https.*api.*")
+HOST_URL=$(oc whoami --show-server 2>/dev/null)
 if [ $? -ne 0 ]; then
     errorf "${RED}ERROR: Make sure you are logged into an OpenShift Container Platform before running this script${CLEAR}\n"
     exit 2

--- a/clusterclaims/reconcile_claims.sh
+++ b/clusterclaims/reconcile_claims.sh
@@ -35,7 +35,7 @@ fi
 #----VALIDATE PREREQ----#
 # User needs to be logged into the cluster
 printf "${BLUE}* Testing connection${CLEAR}\n"
-HOST_URL=$(oc status | grep -o "https.*api.*")
+HOST_URL=$(oc whoami --show-server 2>/dev/null)
 if [ $? -ne 0 ]; then
     errorf "${RED}ERROR: Make sure you are logged into an OpenShift Container Platform before running this script${CLEAR}\n"
     exit 2

--- a/clusterpools/apply.sh
+++ b/clusterpools/apply.sh
@@ -295,7 +295,7 @@ fi
 #----VALIDATE PREREQ----#
 # User needs to be logged into the cluster
 printf "${BLUE}* Testing connection${CLEAR}\n"
-HOST_URL=$(oc status | grep -o "https.*api.*")
+HOST_URL=$(oc whoami --show-server 2>/dev/null)
 if [ $? -ne 0 ]; then
     errorf "${RED}ERROR: Make sure you are logged into an OpenShift Container Platform before running this script${CLEAR}\n"
     exit 2

--- a/clusterpools/delete.sh
+++ b/clusterpools/delete.sh
@@ -35,7 +35,7 @@ fi
 #----VALIDATE PREREQ----#
 # User needs to be logged into the cluster
 printf "${BLUE}* Testing connection${CLEAR}\n"
-HOST_URL=$(oc status | grep -o "https.*api.*")
+HOST_URL=$(oc whoami --show-server 2>/dev/null)
 if [ $? -ne 0 ]; then
     errorf "${RED}ERROR: Make sure you are logged into an OpenShift Container Platform before running this script${CLEAR}\n"
     exit 2


### PR DESCRIPTION
## Description
This PR fixes deprecation warnings about `apps.openshift.io/v1 DeploymentConfig` that appear when running scripts on OpenShift 4.14+ clusters.

## Problem
When executing `reconcile_claims.sh` and other scripts, users see warnings like the following:
```
W0806 08:56:19.287531 55893 warnings.go:70] apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+
```

## Solution
- Replaced `oc status | grep -o "https.*api.*"` with `oc whoami --show-server 2>/dev/null` 
- This approach is more direct and efficient, avoiding API resource discovery that triggers deprecation warnings
- Added stderr redirection to suppress any other potential warnings

## Files Changed
- `clusterclaims/apply.sh`
- `clusterclaims/delete.sh` 
- `clusterclaims/get_credentials.sh`
- `clusterclaims/reconcile_claims.sh`
- `clusterpools/apply.sh`
- `clusterpools/delete.sh`
